### PR TITLE
Adding idempotent requests by creating a superclass IdempotentQuery.

### DIFF
--- a/MagicBell.xcodeproj/project.pbxproj
+++ b/MagicBell.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		59EF99CC27446DAD00FB2378 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = 59EF99CB27446DAD00FB2378 /* Podfile */; };
 		59EF9AC52744710300FB2378 /* MagicBell.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 59EF9AC42744710300FB2378 /* MagicBell.podspec */; };
 		59EF9ACB2744792A00FB2378 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 59EF9ACA2744792A00FB2378 /* LICENSE */; };
+		D2153EF6274E9CB8009C2DDC /* IdempotentQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2153EF5274E9CB8009C2DDC /* IdempotentQuery.swift */; };
 		D2D277262747C9CF00B5F69E /* ActionNotificationNetworkDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D277252747C9CF00B5F69E /* ActionNotificationNetworkDataSource.swift */; };
 		D2D277292747D40A00B5F69E /* NotificationQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D277282747D40A00B5F69E /* NotificationQuery.swift */; };
 		D2D2772B2747D43200B5F69E /* PushSubscriptionQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D2772A2747D43200B5F69E /* PushSubscriptionQuery.swift */; };
@@ -95,6 +96,7 @@
 		9EF8CEE464FC13C082743CBD /* Pods-MagicBell-MagicBellTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MagicBell-MagicBellTests.release.xcconfig"; path = "Target Support Files/Pods-MagicBell-MagicBellTests/Pods-MagicBell-MagicBellTests.release.xcconfig"; sourceTree = "<group>"; };
 		B45D82557E72257F11E3D387 /* libPods-MagicBell-MagicBellTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MagicBell-MagicBellTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5F30FD4909C599F35D72FF1 /* Pods-MagicBell.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MagicBell.release.xcconfig"; path = "Target Support Files/Pods-MagicBell/Pods-MagicBell.release.xcconfig"; sourceTree = "<group>"; };
+		D2153EF5274E9CB8009C2DDC /* IdempotentQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdempotentQuery.swift; sourceTree = "<group>"; };
 		D2D277252747C9CF00B5F69E /* ActionNotificationNetworkDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionNotificationNetworkDataSource.swift; sourceTree = "<group>"; };
 		D2D277282747D40A00B5F69E /* NotificationQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationQuery.swift; sourceTree = "<group>"; };
 		D2D2772A2747D43200B5F69E /* PushSubscriptionQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushSubscriptionQuery.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 		59799E39274659FB00BFB375 /* Query */ = {
 			isa = PBXGroup;
 			children = (
+				D2153EF5274E9CB8009C2DDC /* IdempotentQuery.swift */,
 				59799E3A27465A0E00BFB375 /* UserQuery.swift */,
 			);
 			path = Query;
@@ -539,6 +542,7 @@
 				59C3CDBE274D2BDB0043BA77 /* UserProvider.swift in Sources */,
 				59799E67274660AD00BFB375 /* UserPreferences.swift in Sources */,
 				59799E552746604F00BFB375 /* Config.swift in Sources */,
+				D2153EF6274E9CB8009C2DDC /* IdempotentQuery.swift in Sources */,
 				59799E66274660AD00BFB375 /* UserPreferencesNetworkDataSource.swift in Sources */,
 				59799E69274662E900BFB375 /* NotificationProvider.swift in Sources */,
 				59799E3B27465A0E00BFB375 /* UserQuery.swift in Sources */,

--- a/Source/Core/Common/Query/IdempotentQuery.swift
+++ b/Source/Core/Common/Query/IdempotentQuery.swift
@@ -1,0 +1,12 @@
+//
+//  IdempotentQuery.swift
+//  MagicBell
+//
+//  Created by Joan Martin on 24/11/21.
+//
+
+import Harmony
+
+public class IdempotentQuery: Query {
+    var idempotentKey: String = UUID().uuidString
+}

--- a/Source/Core/Common/Query/UserQuery.swift
+++ b/Source/Core/Common/Query/UserQuery.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Harmony
 
-public class UserQuery: KeyQuery {
+public class UserQuery: IdempotentQuery, KeyQuery {
     let externalId: String?
     let email: String?
 

--- a/Source/Core/Features/Config/Data/ConfigNetworkDataSource.swift
+++ b/Source/Core/Features/Config/Data/ConfigNetworkDataSource.swift
@@ -22,11 +22,12 @@ public class ConfigNetworkDataSource: GetDataSource {
 
     public func get(_ query: Query) -> Future<Config> {
         switch query {
-        case let userQuery as UserQuery:
+        case let query as UserQuery:
             let urlRequest = httpClient.prepareURLRequest(
                 path: "/config",
-                externalId: userQuery.externalId,
-                email: userQuery.email
+                externalId: query.externalId,
+                email: query.email,
+                idempotentKey: query.idempotentKey
             )
             return httpClient
                 .performRequest(urlRequest)

--- a/Source/Core/Features/Notification/Data/ActionNotificationNetworkDataSource.swift
+++ b/Source/Core/Features/Notification/Data/ActionNotificationNetworkDataSource.swift
@@ -18,19 +18,19 @@ public class ActionNotificationNetworkDataSource: PutDataSource, DeleteDataSourc
 
     public func put(_ value: Void?, in query: Query) -> Future<Void> {
         switch query {
-        case let notificationActionQuery as NotificationActionQuery:
+        case let query as NotificationActionQuery:
             var path = "/notifications"
             var httpMethod = "POST"
-            switch notificationActionQuery.action {
+            switch query.action {
             case .markAsRead:
-                path.append("/\(notificationActionQuery.notificationId)/read")
+                path.append("/\(query.notificationId)/read")
             case .markAsUnread:
-                path.append("/\(notificationActionQuery.notificationId)/unread")
+                path.append("/\(query.notificationId)/unread")
             case .unarchive:
-                path.append("/\(notificationActionQuery.notificationId)/archive")
+                path.append("/\(query.notificationId)/archive")
                 httpMethod = "DELETE"
             case .archive:
-                path.append("/\(notificationActionQuery.notificationId)/archive")
+                path.append("/\(query.notificationId)/archive")
             case .markAllAsRead:
                 path.append("/read")
             case .markAllAsSeen:
@@ -39,8 +39,9 @@ public class ActionNotificationNetworkDataSource: PutDataSource, DeleteDataSourc
 
             var urlRequest = self.httpClient.prepareURLRequest(
                 path: path,
-                externalId: notificationActionQuery.user.externalId,
-                email: notificationActionQuery.user.email
+                externalId: query.userQuery.externalId,
+                email: query.userQuery.email,
+                idempotentKey: query.idempotentKey
             )
             urlRequest.httpMethod = httpMethod
 
@@ -58,11 +59,12 @@ public class ActionNotificationNetworkDataSource: PutDataSource, DeleteDataSourc
 
     public func delete(_ query: Query) -> Future<Void> {
         switch query {
-        case let notificationQuery as NotificationQuery:
+        case let query as NotificationQuery:
             var urlRequest = self.httpClient.prepareURLRequest(
-                path: "/notifications/\(notificationQuery.notificationId)",
-                externalId: notificationQuery.user.externalId,
-                email: notificationQuery.user.email
+                path: "/notifications/\(query.notificationId)",
+                externalId: query.userQuery.externalId,
+                email: query.userQuery.email,
+                idempotentKey: query.idempotentKey
             )
             urlRequest.httpMethod = "DELETE"
 

--- a/Source/Core/Features/Notification/Data/NotificationNetworkDataSource.swift
+++ b/Source/Core/Features/Notification/Data/NotificationNetworkDataSource.swift
@@ -22,11 +22,12 @@ public class NotificationNetworkDataSource: GetDataSource {
 
     public func get(_ query: Query) -> Future<Notification> {
         switch query {
-        case let notificationQuery as NotificationQuery:
+        case let query as NotificationQuery:
             let urlRequest = self.httpClient.prepareURLRequest(
-                path: "/notifications/\(notificationQuery.notificationId)",
-                externalId: notificationQuery.user.externalId,
-                email: notificationQuery.user.email
+                path: "/notifications/\(query.notificationId)",
+                externalId: query.userQuery.externalId,
+                email: query.userQuery.email,
+                idempotentKey: query.idempotentKey
             )
             return self.httpClient
                 .performRequest(urlRequest)

--- a/Source/Core/Features/Notification/Data/NotificationQuery.swift
+++ b/Source/Core/Features/Notification/Data/NotificationQuery.swift
@@ -7,13 +7,13 @@
 
 import Harmony
 
-public class NotificationQuery: Query {
-    public let user: UserQuery
+public class NotificationQuery: IdempotentQuery {
+    public let userQuery: UserQuery
     public let notificationId: String
 
     public init(notificationId: String, userQuery: UserQuery) {
         self.notificationId = notificationId
-        user = userQuery
+        self.userQuery = userQuery
     }
 }
 

--- a/Source/Core/Features/PushSubscription/Data/PushSubscriptionNetworkDataSource.swift
+++ b/Source/Core/Features/PushSubscription/Data/PushSubscriptionNetworkDataSource.swift
@@ -22,14 +22,15 @@ class PushSubscriptionNetworkDataSource: PutDataSource, DeleteDataSource {
 
     func put(_ value: PushSubscription?, in query: Query) -> Future<PushSubscription> {
         switch query {
-        case let pushSubscriptionQuery as RegisterPushSubscriptionQuery:
+        case let query as UserQuery:
             guard let value = value else {
                 return Future(NetworkError(message: "Value cannot be nil"))
             }
             var urlRequest = httpClient.prepareURLRequest(
                 path: "/push_subscriptions",
-                externalId: pushSubscriptionQuery.user.externalId,
-                email: pushSubscriptionQuery.user.email
+                externalId: query.externalId,
+                email: query.email,
+                idempotentKey: query.idempotentKey
             )
             urlRequest.httpMethod = "POST"
             do {
@@ -52,11 +53,12 @@ class PushSubscriptionNetworkDataSource: PutDataSource, DeleteDataSource {
 
     public func delete(_ query: Query) -> Future<Void> {
         switch query {
-        case let deletePushSubscriptionQuery as DeletePushSubscriptionQuery:
+        case let query as DeletePushSubscriptionQuery:
             var urlRequest = self.httpClient.prepareURLRequest(
-                path: "/push_subscriptions/\(deletePushSubscriptionQuery.deviceToken)",
-                externalId: deletePushSubscriptionQuery.user.externalId,
-                email: deletePushSubscriptionQuery.user.email
+                path: "/push_subscriptions/\(query.deviceToken)",
+                externalId: query.userQuery.externalId,
+                email: query.userQuery.email,
+                idempotentKey: query.idempotentKey
             )
             urlRequest.httpMethod = "DELETE"
 

--- a/Source/Core/Features/PushSubscription/Data/PushSubscriptionQuery.swift
+++ b/Source/Core/Features/PushSubscription/Data/PushSubscriptionQuery.swift
@@ -7,20 +7,12 @@
 
 import Harmony
 
-public class RegisterPushSubscriptionQuery: Query {
-    public let user: UserQuery
-
-    public init(user: UserQuery) {
-        self.user = user
-    }
-}
-
-public class DeletePushSubscriptionQuery: Query {
-    public let user: UserQuery
+public class DeletePushSubscriptionQuery: IdempotentQuery {
+    public let userQuery: UserQuery
     public let deviceToken: String
 
-    public init(user: UserQuery, deviceToken: String) {
-        self.user = user
+    public init(userQuery: UserQuery, deviceToken: String) {
+        self.userQuery = userQuery
         self.deviceToken = deviceToken
     }
 }

--- a/Source/Core/Features/PushSubscription/PushSubscription.swift
+++ b/Source/Core/Features/PushSubscription/PushSubscription.swift
@@ -11,7 +11,7 @@ public struct PushSubscription: Codable {
     public let id: String?
     public let deviceToken, platform: String
 
-    public init(id: String? = nil, deviceToken: String, platform: String) {
+    public init(id: String? = nil, deviceToken: String, platform: String = "ios") {
         self.id = id
         self.deviceToken = deviceToken
         self.platform = platform

--- a/Source/Core/Features/UserPreferences/Data/UserPreferencesNetworkDataSource.swift
+++ b/Source/Core/Features/UserPreferences/Data/UserPreferencesNetworkDataSource.swift
@@ -26,7 +26,8 @@ public class UserPreferencesNetworkDataSource: GetDataSource, PutDataSource {
             let urlRequest = self.httpClient.prepareURLRequest(
                 path: "/notification_preferences",
                 externalId: userQuery.externalId,
-                email: userQuery.email
+                email: userQuery.email,
+                idempotentKey: userQuery.idempotentKey
             )
             return self.httpClient
                 .performRequest(urlRequest)
@@ -50,7 +51,8 @@ public class UserPreferencesNetworkDataSource: GetDataSource, PutDataSource {
             var urlRequest = self.httpClient.prepareURLRequest(
                 path: "/notification_preferences",
                 externalId: userQuery.externalId,
-                email: userQuery.email
+                email: userQuery.email,
+                idempotentKey: userQuery.idempotentKey
             )
             urlRequest.httpMethod = "PUT"
 


### PR DESCRIPTION
- Adding idempotent requests
- Created superclass IdempotentQuery, which holds the UUID string for the idempotent key
- PROS: Now data sources/repositories/interactors could "retry" the same action with the same query, leading ot the same identified request
- CONS: A Query now cannot be reused. Codebase should be creating queries instead of keeping instances stored and reusing them.